### PR TITLE
Allow overriding breadcrumbs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -173,7 +173,9 @@ require get_template_directory() . '/framework/functions/flexia/widgets.php';
  * Breadcrumbs.
  */
 
-require get_template_directory() . '/framework/functions/flexia/breadcrumb.php';
+if ( ! function_exists( 'flexia_breadcrumbs' ) ) {
+	require get_template_directory() . '/framework/functions/flexia/breadcrumb.php';
+}
 
 /**
  * Integrations.


### PR DESCRIPTION
The theme's breadcrumb system, while sufficient for most users, lacks the flexibility of the likes of Yoast's breadcrumb system. By adding the function_exists check, advanced users can easily replace the breadcrumb output with something else.